### PR TITLE
[vmware] use Vmdk handles and remove temporary local files

### DIFF
--- a/os_brick/initiator/connectors/vmware.py
+++ b/os_brick/initiator/connectors/vmware.py
@@ -116,11 +116,12 @@ class VmdkConnector(initiator_connector.InitiatorConnector):
                                     'VirtualMachine')
 
         return rw_handles.VmdkReadHandle(session,
-                                           self._ip,
-                                           self._port,
-                                           vm_ref,
-                                           None,
-                                           connection_properties['vmdk_size'])
+                                         self._ip,
+                                         self._port,
+                                         vm_ref,
+                                         None,
+                                         connection_properties['vmdk_size'],
+                                         update_progress=True)
 
     def _connect_volume_write_handle(self, session, connection_properties):
         vmdk_size = connection_properties['vmdk_size']

--- a/os_brick/initiator/connectors/vmware.py
+++ b/os_brick/initiator/connectors/vmware.py
@@ -157,7 +157,8 @@ class VmdkConnector(initiator_connector.InitiatorConnector):
             folder,
             import_spec,
             file_size,
-            'POST')
+            http_method='POST',
+            update_progress=True)
 
     def disconnect_volume(self, connection_properties, device_info,
                           force=False, ignore_errors=False):

--- a/os_brick/initiator/connectors/vmware.py
+++ b/os_brick/initiator/connectors/vmware.py
@@ -13,11 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import os
-import tempfile
-
 from oslo_log import log as logging
-from oslo_utils import fileutils
 try:
     from oslo_vmware import api
     from oslo_vmware import exceptions as oslo_vmw_exceptions
@@ -27,7 +23,6 @@ try:
     from oslo_vmware import vim_util
 except ImportError:
     vim_util = None
-import six
 
 from os_brick import exception
 from os_brick.i18n import _
@@ -41,8 +36,6 @@ class VmdkConnector(initiator_connector.InitiatorConnector):
 
     This connector is only used for backup and restore of Cinder volumes.
     """
-
-    TMP_IMAGES_DATASTORE_FOLDER_PATH = "cinder_temp"
 
     def __init__(self, *args, **kwargs):
         # Check if oslo.vmware library is available.
@@ -69,15 +62,8 @@ class VmdkConnector(initiator_connector.InitiatorConnector):
         return {}
 
     def check_valid_device(self, path, *args, **kwargs):
-        try:
-            with open(path, 'r') as dev:
-                dev.read(1)
-        except IOError:
-            LOG.exception(
-                "Failed to access the device on the path "
-                "%(path)s", {"path": path})
-            return False
-        return True
+        return isinstance(path, rw_handles.VmdkReadHandle) or isinstance(
+            path, rw_handles.VmdkWriteHandle)
 
     def get_volume_paths(self, connection_properties):
         return []
@@ -111,48 +97,39 @@ class VmdkConnector(initiator_connector.InitiatorConnector):
                                     cacert=self._ca_file,
                                     insecure=self._insecure)
 
-    def _create_temp_file(self, *args, **kwargs):
-        fileutils.ensure_tree(self._tmp_dir)
-        fd, tmp = tempfile.mkstemp(dir=self._tmp_dir, *args, **kwargs)
-        os.close(fd)
-        return tmp
-
-    def _download_vmdk(
-            self, tmp_file_path, session, backing, vmdk_path, vmdk_size):
-        with open(tmp_file_path, "wb") as tmp_file:
-            image_transfer.copy_stream_optimized_disk(
-                None,
-                self._timeout,
-                tmp_file,
-                session=session,
-                host=self._ip,
-                port=self._port,
-                vm=backing,
-                vmdk_file_path=vmdk_path,
-                vmdk_size=vmdk_size)
-
     def connect_volume(self, connection_properties):
-        # Download the volume vmdk from vCenter server to a temporary file
-        # and return its path.
         self._load_config(connection_properties)
         session = self._create_session()
+        # when import_data is passed in, we know we have to connect for a write
+        # operation (a volume backup restore)
+        if connection_properties.get('import_data'):
+            handle = self._connect_volume_write_handle(session,
+                                                       connection_properties)
+        # otherwise we connect for a read operation
+        else:
+            handle = self._connect_volume_read_handle(session,
+                                                      connection_properties)
+        return {'path': handle}
 
-        tmp_file_path = self._create_temp_file(
-            suffix=".vmdk", prefix=connection_properties['volume_id'])
-        backing = vim_util.get_moref(connection_properties['volume'],
-                                     "VirtualMachine")
-        vmdk_path = connection_properties['vmdk_path']
+    def _connect_volume_read_handle(self, session, connection_properties):
+        vm_ref = vim_util.get_moref(connection_properties['volume'],
+                                    'VirtualMachine')
+
+        return rw_handles.VmdkReadHandle(session,
+                                           self._ip,
+                                           self._port,
+                                           vm_ref,
+                                           None,
+                                           connection_properties['vmdk_size'])
+
+    def _connect_volume_write_handle(self, session, connection_properties):
         vmdk_size = connection_properties['vmdk_size']
-        try:
-            self._download_vmdk(
-                tmp_file_path, session, backing, vmdk_path, vmdk_size)
-        finally:
-            session.logout()
-
-        # Save the last modified time of the temporary so that we can decide
-        # whether to upload the file back to vCenter server during disconnect.
-        last_modified = os.path.getmtime(tmp_file_path)
-        return {'path': tmp_file_path, 'last_modified': last_modified}
+        import_data = connection_properties['import_data']
+        import_data['profile_id'] = connection_properties['profile_id']
+        # we create the new backing with a temporary name. The cinder vmdk
+        # driver will know how to rename it in `terminate_connection()`
+        import_data['vm']['name'] = "%s_brick" % connection_properties['name']
+        return self._get_write_handle(import_data, session, vmdk_size)
 
     def _snapshot_exists(self, session, backing):
         snapshot = session.invoke_api(vim_util,
@@ -164,98 +141,16 @@ class VmdkConnector(initiator_connector.InitiatorConnector):
             return False
         return len(snapshot.rootSnapshotList) != 0
 
-    def _create_temp_ds_folder(self, session, ds_folder_path, dc_ref):
-        fileManager = session.vim.service_content.fileManager
-        try:
-            session.invoke_api(session.vim,
-                               'MakeDirectory',
-                               fileManager,
-                               name=ds_folder_path,
-                               datacenter=dc_ref)
-        except oslo_vmw_exceptions.FileAlreadyExistsException:
-            pass
-
-    # Note(vbala) remove this method when we implement it in oslo.vmware
-    def _upload_vmdk(
-            self, read_handle, host, port, dc_name, ds_name, cookies,
-            upload_file_path, file_size, cacerts, timeout_secs):
-        write_handle = rw_handles.FileWriteHandle(host,
-                                                  port,
-                                                  dc_name,
-                                                  ds_name,
-                                                  cookies,
-                                                  upload_file_path,
-                                                  file_size,
-                                                  cacerts=cacerts)
-        image_transfer._start_transfer(read_handle, write_handle, timeout_secs)
-
-    def _disconnect(self, session, tmp_file_path, tmp_file, tmp_file_size,
-                    ds_ref, dc_ref, vmdk_path):
-        # The restored volume is in compressed (streamOptimized) format.
-        # So we upload it to a temporary location in vCenter datastore and copy
-        # the compressed vmdk to the volume vmdk. The copy operation
-        # decompresses the disk to a format suitable for attaching to Nova
-        # instances in vCenter.
-        dstore = datastore.get_datastore_by_ref(session, ds_ref)
-        ds_path = dstore.build_path(
-            VmdkConnector.TMP_IMAGES_DATASTORE_FOLDER_PATH,
-            os.path.basename(tmp_file_path))
-        self._create_temp_ds_folder(
-            session, six.text_type(ds_path.parent), dc_ref)
-
-        dc_name = session.invoke_api(
-                vim_util, 'get_object_property', session.vim, dc_ref, 'name')
-        cookies = session.vim.client.options.transport.cookiejar
-        cacerts = self._ca_file if self._ca_file else not self._insecure
-        self._upload_vmdk(
-                tmp_file, self._ip, self._port, dc_name, dstore.name, cookies,
-                ds_path.rel_path, tmp_file_size, cacerts,
-                self._timeout)
-
-        # Delete the current volume vmdk because the copy operation does not
-        # overwrite.
-        LOG.debug("Deleting %s", vmdk_path)
-        disk_mgr = session.vim.service_content.virtualDiskManager
-        task = session.invoke_api(session.vim,
-                                  'DeleteVirtualDisk_Task',
-                                  disk_mgr,
-                                  name=vmdk_path,
-                                  datacenter=dc_ref)
-        session.wait_for_task(task)
-
-        src = six.text_type(ds_path)
-        LOG.debug("Copying %(src)s to %(dest)s", {'src': src,
-                                                  'dest': vmdk_path})
-        task = session.invoke_api(session.vim,
-                                  'CopyVirtualDisk_Task',
-                                  disk_mgr,
-                                  sourceName=src,
-                                  sourceDatacenter=dc_ref,
-                                  destName=vmdk_path,
-                                  destDatacenter=dc_ref)
-        session.wait_for_task(task)
-
-        # Delete the compressed vmdk at the temporary location.
-        LOG.debug("Deleting %s", src)
-        file_mgr = session.vim.service_content.fileManager
-        task = session.invoke_api(session.vim,
-                                  'DeleteDatastoreFile_Task',
-                                  file_mgr,
-                                  name=src,
-                                  datacenter=dc_ref)
-        session.wait_for_task(task)
-
-    def _disconnect_with_import(self, import_data, volume_ops, backing,
-                                tmp_file, file_size):
+    def _get_write_handle(self, import_data, session, file_size):
+        volume_ops = VolumeOps(session)
         import_spec = volume_ops.get_import_spec(import_data)
         folder = vim_util.get_moref(import_data['folder'],
                                     'Folder')
         rp = vim_util.get_moref(import_data['resource_pool'],
                                 'ResourcePool')
 
-        volume_ops.delete_backing(backing)
-        write_handle = rw_handles.VmdkWriteHandle(
-            volume_ops._session,
+        return rw_handles.VmdkWriteHandle(
+            session,
             self._ip,
             self._port,
             rp,
@@ -263,62 +158,31 @@ class VmdkConnector(initiator_connector.InitiatorConnector):
             import_spec,
             file_size,
             'POST')
-        image_transfer._start_transfer(tmp_file, write_handle, self._timeout)
 
     def disconnect_volume(self, connection_properties, device_info,
                           force=False, ignore_errors=False):
-        tmp_file_path = device_info['path']
-        if not os.path.exists(tmp_file_path):
-            msg = _("Vmdk: %s not found.") % tmp_file_path
-            raise exception.NotFound(message=msg)
+        vmdk_handle = device_info['path']
+        vmdk_handle.close()
+        session = vmdk_handle._session
+        if connection_properties.get('import_data'):
+            volume_ops = VolumeOps(session)
+            backing = vim_util.get_moref(connection_properties['volume'],
+                                         "VirtualMachine")
+            new_backing = vmdk_handle.get_imported_vm()
+            # Currently there is no way we can restore the volume if it
+            # contains redo-log based snapshots (bug 1599026).
+            if self._snapshot_exists(session, backing):
+                volume_ops.delete_backing(new_backing)
+                msg = (_("Backing of volume: %s contains one or more "
+                         "snapshots; cannot disconnect.") %
+                       connection_properties['volume_id'])
+                raise exception.BrickException(message=msg)
 
-        session = None
-        try:
-            # We upload the temporary file to vCenter server only if it is
-            # modified after connect_volume.
-            if os.path.getmtime(tmp_file_path) > device_info['last_modified']:
-                self._load_config(connection_properties)
-                session = self._create_session()
-                backing = vim_util.get_moref(connection_properties['volume'],
-                                             "VirtualMachine")
-                # Currently there is no way we can restore the volume if it
-                # contains redo-log based snapshots (bug 1599026).
-                if self._snapshot_exists(session, backing):
-                    msg = (_("Backing of volume: %s contains one or more "
-                             "snapshots; cannot disconnect.") %
-                           connection_properties['volume_id'])
-                    raise exception.BrickException(message=msg)
+            volume_ops.delete_backing(backing)
+            volume_ops.update_instance_uuid(new_backing,
+                                            connection_properties['volume_id'])
 
-                ds_ref = vim_util.get_moref(
-                    connection_properties['datastore'], "Datastore")
-                dc_ref = vim_util.get_moref(
-                    connection_properties['datacenter'], "Datacenter")
-                vmdk_path = connection_properties['vmdk_path']
-
-                with open(tmp_file_path, "rb") as tmp_file:
-                    file_size = os.path.getsize(tmp_file_path)
-                    import_data = connection_properties.get('import_data')
-                    if import_data:
-                        import_data = connection_properties['import_data']
-                        import_data['profile_id'] = connection_properties[
-                            'profile_id']
-                        import_data['vm']['name'] = connection_properties[
-                            'name']
-                        import_data['vm']['uuid'] = connection_properties[
-                            'volume_id']
-                        self._disconnect_with_import(import_data,
-                                                     VolumeOps(session),
-                                                     backing,
-                                                     tmp_file,
-                                                     file_size)
-                    else:
-                        self._disconnect(session, tmp_file_path, tmp_file,
-                                         file_size, ds_ref, dc_ref,
-                                         vmdk_path)
-        finally:
-            os.remove(tmp_file_path)
-            if session:
-                session.logout()
+        session.logout()
 
     def extend_volume(self, connection_properties):
         raise NotImplementedError
@@ -336,6 +200,16 @@ class VolumeOps:
 
         return vm_import_spec
 
+    def update_instance_uuid(self, vm_ref, uuid):
+        cf = self._session.vim.client.factory
+        config_spec = cf.create('ns0:VirtualMachineConfigSpec')
+        config_spec.instanceUuid = uuid
+        task = self._session.invoke_api(self._session.vim,
+                                        'ReconfigVM_Task',
+                                         vm_ref,
+                                         spec=config_spec)
+        self._session.wait_for_task(task)
+
     def get_vm_config_spec(self, import_data):
         vm = import_data['vm']
         cf = self._session.vim.client.factory
@@ -349,7 +223,6 @@ class VolumeOps:
         config_spec.memoryMB = vm['memory_mb']
         config_spec.files = vm_file_info
         config_spec.version = vm['vmx_version']
-        config_spec.instanceUuid = vm['uuid']
 
         extra_config = vm['extra_config']
         if extra_config:

--- a/os_brick/tests/initiator/connectors/test_vmware.py
+++ b/os_brick/tests/initiator/connectors/test_vmware.py
@@ -98,54 +98,6 @@ class VmdkConnectorTestCase(test_connector.ConnectorTestCase):
             cacert=self._connector._ca_file,
             insecure=self._connector._insecure)
 
-    @mock.patch('oslo_utils.fileutils.ensure_tree')
-    @mock.patch('tempfile.mkstemp')
-    @mock.patch('os.close')
-    def test_create_temp_file(
-            self, close, mkstemp, ensure_tree):
-        fd = mock.sentinel.fd
-        tmp = mock.sentinel.tmp
-        mkstemp.return_value = (fd, tmp)
-
-        prefix = ".vmdk"
-        suffix = "test"
-        ret = self._connector._create_temp_file(prefix=prefix, suffix=suffix)
-
-        self.assertEqual(tmp, ret)
-        ensure_tree.assert_called_once_with(self._connector._tmp_dir)
-        mkstemp.assert_called_once_with(dir=self._connector._tmp_dir,
-                                        prefix=prefix,
-                                        suffix=suffix)
-        close.assert_called_once_with(fd)
-
-    @mock.patch('os_brick.initiator.connectors.vmware.open', create=True)
-    @mock.patch('oslo_vmware.image_transfer.copy_stream_optimized_disk')
-    def test_download_vmdk(self, copy_disk, file_open):
-        file_open_ret = mock.Mock()
-        tmp_file = mock.sentinel.tmp_file
-        file_open_ret.__enter__ = mock.Mock(return_value=tmp_file)
-        file_open_ret.__exit__ = mock.Mock(return_value=None)
-        file_open.return_value = file_open_ret
-
-        tmp_file_path = mock.sentinel.tmp_file_path
-        session = mock.sentinel.session
-        backing = mock.sentinel.backing
-        vmdk_path = mock.sentinel.vmdk_path
-        vmdk_size = mock.sentinel.vmdk_size
-        self._connector._download_vmdk(
-            tmp_file_path, session, backing, vmdk_path, vmdk_size)
-
-        file_open.assert_called_once_with(tmp_file_path, 'wb')
-        copy_disk.assert_called_once_with(None,
-                                          self._connector._timeout,
-                                          tmp_file,
-                                          session=session,
-                                          host=self._connector._ip,
-                                          port=self._connector._port,
-                                          vm=backing,
-                                          vmdk_file_path=vmdk_path,
-                                          vmdk_size=vmdk_size)
-
     def _create_connection_properties(self):
         return {'volume_id': 'ed083474-d325-4a99-b301-269111654f0d',
                 'volume': 'ref-1',
@@ -159,38 +111,112 @@ class VmdkConnectorTestCase(test_connector.ConnectorTestCase):
 
     @mock.patch.object(VMDK_CONNECTOR, '_load_config')
     @mock.patch.object(VMDK_CONNECTOR, '_create_session')
-    @mock.patch.object(VMDK_CONNECTOR, '_create_temp_file')
-    @mock.patch('oslo_vmware.vim_util.get_moref')
-    @mock.patch.object(VMDK_CONNECTOR, '_download_vmdk')
-    @mock.patch('os.path.getmtime')
+    @mock.patch.object(VMDK_CONNECTOR, '_connect_volume_write_handle')
+    @mock.patch.object(VMDK_CONNECTOR, '_connect_volume_read_handle')
     def test_connect_volume(
-            self, getmtime, download_vmdk, get_moref, create_temp_file,
-            create_session, load_config):
-        session = mock.Mock()
-        create_session.return_value = session
-
-        tmp_file_path = mock.sentinel.tmp_file_path
-        create_temp_file.return_value = tmp_file_path
-
-        backing = mock.sentinel.backing
-        get_moref.return_value = backing
-
-        last_modified = mock.sentinel.last_modified
-        getmtime.return_value = last_modified
+            self, connect_volume_read_handle, connect_volume_write_handle,
+            create_session, load_config, write=False):
 
         props = self._create_connection_properties()
+        if write:
+            props['import_data'] = {'vm': {}}
+
+        session = mock.Mock()
+        read_handle = mock.Mock()
+        write_handle = mock.Mock()
+
+        connect_volume_write_handle.return_value = write_handle
+        connect_volume_read_handle.return_value = read_handle
+        create_session.return_value = session
+
         ret = self._connector.connect_volume(props)
 
-        self.assertEqual(tmp_file_path, ret['path'])
-        self.assertEqual(last_modified, ret['last_modified'])
         load_config.assert_called_once_with(props)
         create_session.assert_called_once_with()
-        create_temp_file.assert_called_once_with(
-            suffix=".vmdk", prefix=props['volume_id'])
-        download_vmdk.assert_called_once_with(
-            tmp_file_path, session, backing, props['vmdk_path'],
-            props['vmdk_size'])
-        session.logout.assert_called_once_with()
+        handle = None
+        if write:
+            connect_volume_write_handle.assert_called_once_with(session, props)
+            handle = write_handle
+        else:
+            connect_volume_read_handle.assert_called_once_with(session, props)
+            handle = read_handle
+
+        self.assertEqual(ret, {'path': handle})
+
+    def test_connect_volume_with_write(self):
+        self.test_connect_volume(write=True)
+
+    @mock.patch('oslo_vmware.vim_util.get_moref')
+    @mock.patch('oslo_vmware.rw_handles.VmdkReadHandle')
+    def test_connect_volume_read_handle(self, vmdk_read_handle, get_moref):
+        props = self._create_connection_properties()
+        session = mock.Mock()
+        vm_ref = mock.Mock()
+        vmdk_read_handle_ret = mock.Mock()
+        vmdk_read_handle.return_value = vmdk_read_handle_ret
+        get_moref.return_value = vm_ref
+        ret = self._connector._connect_volume_read_handle(session, props)
+        get_moref.assert_called_once_with(props['volume'], 'VirtualMachine')
+        vmdk_read_handle.assert_called_once_with(session,
+                                                 self._connector._ip,
+                                                 self._connector._port,
+                                                 vm_ref,
+                                                 None,
+                                                 props['vmdk_size'])
+        self.assertEqual(ret, vmdk_read_handle_ret)
+
+    @mock.patch.object(VMDK_CONNECTOR, '_get_write_handle')
+    def test_connect_volume_write_handle(self, get_write_handle):
+        props = self._create_connection_properties()
+        props['import_data'] = {'vm': {}}
+        session = mock.Mock()
+
+        self._connector._connect_volume_write_handle(session, props)
+        get_write_handle.assert_called_once_with(props['import_data'],
+                                                 session,
+                                                 props['vmdk_size'])
+        self.assertEqual(props['import_data']['vm']['name'], props['name'] +
+                         '_brick')
+        self.assertEqual(props['import_data']['profile_id'],
+                         props['profile_id'])
+
+    @mock.patch('os_brick.initiator.connectors.vmware.VolumeOps')
+    @mock.patch('oslo_vmware.vim_util.get_moref')
+    @mock.patch('oslo_vmware.rw_handles.VmdkWriteHandle')
+    def test_get_write_handle(self, vmdk_write_handle, get_moref, vops):
+        import_data = {
+            'folder': mock.Mock(),
+            'resource_pool': mock.Mock()
+        }
+        rp = mock.Mock(value=import_data['resource_pool'])
+        folder = mock.Mock(value=import_data['folder'])
+        vops_ret = mock.Mock()
+        vops.return_value = vops_ret
+        session = mock.Mock()
+        import_spec = mock.Mock()
+        file_size = units.Gi
+        get_moref.side_effect = [folder, rp]
+        vmdk_write_handle_ret = mock.Mock()
+        vmdk_write_handle.return_value = vmdk_write_handle_ret
+        vops_ret.get_import_spec.return_value = import_spec
+
+        ret = self._connector._get_write_handle(import_data, session, file_size)
+        vops.assert_called_once_with(session)
+        vops_ret.get_import_spec.assert_called_once_with(import_data)
+        get_moref.assert_has_calls([
+            mock.call(import_data['folder'], 'Folder'),
+            mock.call(import_data['resource_pool'], 'ResourcePool')
+        ])
+        vmdk_write_handle.assert_called_once_with(session,
+                                                  self._connector._ip,
+                                                  self._connector._port,
+                                                  rp,
+                                                  folder,
+                                                  import_spec,
+                                                  file_size,
+                                                  'POST')
+        self.assertEqual(ret, vmdk_write_handle_ret)
+
 
     @ddt.data((None, False), ([mock.sentinel.snap], True))
     @ddt.unpack
@@ -206,229 +232,55 @@ class VmdkConnectorTestCase(test_connector.ConnectorTestCase):
         session.invoke_api.assert_called_once_with(
             vim_util, 'get_object_property', session.vim, backing, 'snapshot')
 
-    def test_create_temp_ds_folder(self):
-        session = mock.Mock()
-        ds_folder_path = mock.sentinel.ds_folder_path
-        dc_ref = mock.sentinel.dc_ref
-        self._connector._create_temp_ds_folder(session, ds_folder_path, dc_ref)
-
-        session.invoke_api.assert_called_once_with(
-            session.vim,
-            'MakeDirectory',
-            session.vim.service_content.fileManager,
-            name=ds_folder_path,
-            datacenter=dc_ref)
-
-    @mock.patch('oslo_vmware.objects.datastore.get_datastore_by_ref')
-    @mock.patch.object(VMDK_CONNECTOR, '_create_temp_ds_folder')
-    @mock.patch.object(VMDK_CONNECTOR, '_upload_vmdk')
-    def test_disconnect(self, upload_vmdk, create_temp_ds_folder,
-                        get_ds_by_ref):
-        ds_ref = mock.sentinel.ds_ref
-        ds_name = 'datastore-1'
-        dstore = datastore.Datastore(ds_ref, ds_name)
-        get_ds_by_ref.return_value = dstore
-
-        tmp_file = mock.sentinel.tmp_file
-
-        dc_name = mock.sentinel.dc_name
-        delete_task = mock.sentinel.delete_vdisk_task
-        copy_task = mock.sentinel.copy_vdisk_task
-        delete_file_task = mock.sentinel.delete_file_task
-        session = mock.Mock()
-        session.invoke_api.side_effect = [
-            dc_name, delete_task, copy_task, delete_file_task]
-
-        tmp_file_path = '/tmp/foo.vmdk'
-        dc_ref = mock.sentinel.dc_ref
-        vmdk_path = mock.sentinel.vmdk_path
-        file_size = 1024
-        self._connector._disconnect(
-            session, tmp_file_path, tmp_file, file_size, ds_ref, dc_ref,
-            vmdk_path)
-
-        tmp_folder_path = self._connector.TMP_IMAGES_DATASTORE_FOLDER_PATH
-        ds_folder_path = '[%s] %s' % (ds_name, tmp_folder_path)
-        create_temp_ds_folder.assert_called_once_with(
-            session, ds_folder_path, dc_ref)
-
-        self.assertEqual(
-            mock.call(vim_util, 'get_object_property', session.vim, dc_ref,
-                      'name'), session.invoke_api.call_args_list[0])
-
-        exp_rel_path = '%s/foo.vmdk' % tmp_folder_path
-        upload_vmdk.assert_called_once_with(
-            tmp_file, self._connector._ip, self._connector._port, dc_name,
-            ds_name, session.vim.client.options.transport.cookiejar,
-            exp_rel_path, file_size, self._connector._ca_file,
-            self._connector._timeout)
-
-        disk_mgr = session.vim.service_content.virtualDiskManager
-        self.assertEqual(
-            mock.call(session.vim, 'DeleteVirtualDisk_Task', disk_mgr,
-                      name=vmdk_path, datacenter=dc_ref),
-            session.invoke_api.call_args_list[1])
-        self.assertEqual(mock.call(delete_task),
-                         session.wait_for_task.call_args_list[0])
-
-        src = '[%s] %s' % (ds_name, exp_rel_path)
-        self.assertEqual(
-            mock.call(session.vim, 'CopyVirtualDisk_Task', disk_mgr,
-                      sourceName=src, sourceDatacenter=dc_ref,
-                      destName=vmdk_path, destDatacenter=dc_ref),
-            session.invoke_api.call_args_list[2])
-        self.assertEqual(mock.call(copy_task),
-                         session.wait_for_task.call_args_list[1])
-
-        file_mgr = session.vim.service_content.fileManager
-        self.assertEqual(
-            mock.call(session.vim, 'DeleteDatastoreFile_Task', file_mgr,
-                      name=src, datacenter=dc_ref),
-            session.invoke_api.call_args_list[3])
-        self.assertEqual(mock.call(delete_file_task),
-                         session.wait_for_task.call_args_list[2])
-
-    @mock.patch('oslo_vmware.image_transfer._start_transfer')
-    @mock.patch('oslo_vmware.rw_handles.VmdkWriteHandle')
-    @mock.patch('oslo_vmware.vim_util.get_moref')
     @mock.patch('os_brick.initiator.connectors.vmware.VolumeOps')
-    def test_disconnect_with_import(self, vops, get_moref, vmdk_write_handle,
-                                    start_transfer):
-        import_spec = mock.Mock()
-        session = mock.sentinel.session
-        backing = mock.sentinel.backing
-        tmp_file = mock.sentinel.file
-        file_size = 1024
-        import_data = {
-            'folder': mock.sentinel.folder,
-            'resource_pool': mock.sentinel.resource_pool
-        }
-        vops._session = mock.sentinel._session
-        vops.get_import_spec.return_value = import_spec
-        get_moref.side_effect = [import_data['folder'], import_data[
-            'resource_pool']]
-        vmdk_write_handle_ret = mock.sentinel.vmdk_write_handle
-        vmdk_write_handle.return_value = vmdk_write_handle_ret
-
-        self._connector._disconnect_with_import(import_data, vops,
-                                                backing, tmp_file, file_size)
-
-        vops.delete_backing.assert_called_once_with(backing)
-
-        vmdk_write_handle.assert_called_once_with(vops._session,
-                                    self._connector._ip,
-                                    self._connector._port,
-                                    import_data['resource_pool'],
-                                    import_data['folder'],
-                                    import_spec,
-                                    file_size,
-                                    'POST')
-
-        start_transfer.assert_called_once_with(tmp_file,
-                                               vmdk_write_handle_ret,
-                                               self._connector._timeout)
-
-
-    @mock.patch('os.path.exists')
-    def test_disconnect_volume_with_missing_temp_file(self, path_exists):
-        path_exists.return_value = False
-
-        path = mock.sentinel.path
-        self.assertRaises(exception.NotFound,
-                          self._connector.disconnect_volume,
-                          mock.ANY,
-                          {'path': path})
-        path_exists.assert_called_once_with(path)
-
-    @mock.patch('os.path.exists')
-    @mock.patch('os.path.getmtime')
-    @mock.patch.object(VMDK_CONNECTOR, '_disconnect')
-    @mock.patch('os.remove')
-    def test_disconnect_volume_with_unmodified_file(
-            self, remove, disconnect, getmtime, path_exists):
-        path_exists.return_value = True
-
-        mtime = 1467802060
-        getmtime.return_value = mtime
-
-        path = mock.sentinel.path
-        self._connector.disconnect_volume(mock.ANY, {'path': path,
-                                                     'last_modified': mtime})
-
-        path_exists.assert_called_once_with(path)
-        getmtime.assert_called_once_with(path)
-        disconnect.assert_not_called()
-        remove.assert_called_once_with(path)
-
-    @mock.patch('os_brick.initiator.connectors.vmware.VolumeOps')
-    @mock.patch('os_brick.initiator.connectors.vmware.open', create=True)
-    @mock.patch('os.path.getsize')
-    @mock.patch('os.path.exists')
-    @mock.patch('os.path.getmtime')
-    @mock.patch.object(VMDK_CONNECTOR, '_load_config')
-    @mock.patch.object(VMDK_CONNECTOR, '_create_session')
     @mock.patch('oslo_vmware.vim_util.get_moref')
     @mock.patch.object(VMDK_CONNECTOR, '_snapshot_exists')
-    @mock.patch.object(VMDK_CONNECTOR, '_disconnect')
-    @mock.patch('os.remove')
-    @mock.patch.object(VMDK_CONNECTOR, '_disconnect_with_import')
-    def test_disconnect_volume(
-            self, disconnect_with_import, remove, disconnect, snapshot_exists,
-            get_moref, create_session, load_config, getmtime, path_exists,
-            path_getsize, open_file, vops, import_data=False):
-
-        path_exists.return_value = True
-        file_size = 1024
-        path_getsize.return_value = file_size
-        mtime = 1467802060
-        getmtime.return_value = mtime
-
-        session = mock.Mock()
-        create_session.return_value = session
-
-        snapshot_exists.return_value = False
-
-        backing = mock.sentinel.backing
-        ds_ref = mock.sentinel.ds_ref
-        dc_ref = mock.sentinel.dc_ref
-        get_moref.side_effect = [backing, ds_ref, dc_ref]
-
+    def test_disconnect_volume(self, snapshot_exists, get_moref, vops,
+                               import_data=None,
+                               has_snapshot=False):
         props = self._create_connection_properties()
-        if import_data:
-            props['import_data'] = {'vm': {}}
-
-        path = mock.sentinel.path
-        tmp_file = mock.sentinel.tmp_file
-        file_open_ret = mock.Mock()
-        file_open_ret.__enter__ = mock.Mock(return_value=tmp_file)
-        file_open_ret.__exit__ = mock.Mock(return_value=None)
-        open_file.return_value = file_open_ret
+        session = mock.Mock()
+        vmdk_handle = mock.Mock(_session=session)
         vops_ret = mock.Mock(_session=session)
         vops.return_value = vops_ret
 
-        self._connector.disconnect_volume(props, {'path': path,
-                                                  'last_modified': mtime - 1})
-        path_exists.assert_called_once_with(path)
-        getmtime.assert_called_once_with(path)
-        open_file.assert_called_once_with(path, "rb")
-        load_config.assert_called_once_with(props)
-        create_session.assert_called_once_with()
-        snapshot_exists.assert_called_once_with(session, backing)
-        path_getsize.assert_called_once_with(path)
+        backing = mock.Mock()
+        new_backing = mock.Mock()
         if import_data:
-            disconnect.assert_not_called()
-            disconnect_with_import.assert_called_once_with(
-                props['import_data'], vops_ret, backing, tmp_file, file_size)
+            props['import_data'] = import_data
+            get_moref.return_value = backing
+            vmdk_handle.get_imported_vm.return_value = new_backing
+            snapshot_exists.return_value = has_snapshot
+
+        device_info = {'path': vmdk_handle}
+        if has_snapshot:
+            self.assertRaises(exception.BrickException,
+                              self._connector.disconnect_volume,
+                              props, device_info)
         else:
-            disconnect.assert_called_once_with(
-            session, path, tmp_file, file_size, ds_ref, dc_ref,
-                props['vmdk_path'])
-            disconnect_with_import.assert_not_called()
-        remove.assert_called_once_with(path)
+            self._connector.disconnect_volume(props, device_info)
+
+        vmdk_handle.close.assert_called_once_with()
+
+        if import_data:
+            vops.assert_called_once_with(session)
+            get_moref.assert_called_once_with(props['volume'], 'VirtualMachine')
+            vmdk_handle.get_imported_vm.assert_called_once_with()
+            snapshot_exists.assert_called_once_with(session, backing)
+            if has_snapshot:
+                vops_ret.delete_backing.assert_called_once_with(new_backing)
+            else:
+                vops_ret.delete_backing.assert_called_once_with(backing)
+                vops_ret.update_instance_uuid.assert_called_once_with(
+                    new_backing, props['volume_id'])
+
         session.logout.assert_called_once_with()
 
-    def test_disconnect_volume_with_import(self):
-        self.test_disconnect_volume(import_data=True)
+    def test_disconnect_volume_write_without_snapshot(self):
+        self.test_disconnect_volume(import_data={'vm': {}})
+
+    def test_disconnect_volume_write_having_snapshot(self):
+        self.test_disconnect_volume(import_data={'vm': {}}, has_snapshot=False)
 
     @staticmethod
     def _create_import_data(folder=None, rp=None):
@@ -513,7 +365,6 @@ class VmdkConnectorTestCase(test_connector.ConnectorTestCase):
         self.assertEqual(spec.memoryMB, vm['memory_mb'])
         self.assertEqual(spec.files, vm_file_info)
         self.assertEqual(spec.version, vm['vmx_version'])
-        self.assertEqual(spec.instanceUuid, vm['uuid'])
         self.assertEqual(spec.extraConfig, [extra_config])
         self.assertEqual(spec.vmProfile, vm_profile)
         self.assertEqual(spec.vmProfile.profileId, data['profile_id'])

--- a/os_brick/tests/initiator/connectors/test_vmware.py
+++ b/os_brick/tests/initiator/connectors/test_vmware.py
@@ -38,6 +38,7 @@ class VmdkConnectorTestCase(test_connector.ConnectorTestCase):
     IMG_TX_TIMEOUT = 10
 
     VMDK_CONNECTOR = vmware.VmdkConnector
+    VMDK_VOLUMEOPS = vmware.VolumeOps
 
     def setUp(self):
         super(VmdkConnectorTestCase, self).setUp()
@@ -149,6 +150,8 @@ class VmdkConnectorTestCase(test_connector.ConnectorTestCase):
         return {'volume_id': 'ed083474-d325-4a99-b301-269111654f0d',
                 'volume': 'ref-1',
                 'vmdk_path': '[ds] foo/bar.vmdk',
+                'profile_id': 'profile-1',
+                'name': 'volume-name-001',
                 'vmdk_size': units.Gi,
                 'datastore': 'ds-1',
                 'datacenter': 'dc-1',
@@ -218,22 +221,15 @@ class VmdkConnectorTestCase(test_connector.ConnectorTestCase):
 
     @mock.patch('oslo_vmware.objects.datastore.get_datastore_by_ref')
     @mock.patch.object(VMDK_CONNECTOR, '_create_temp_ds_folder')
-    @mock.patch('os_brick.initiator.connectors.vmware.open', create=True)
     @mock.patch.object(VMDK_CONNECTOR, '_upload_vmdk')
-    @mock.patch('os.path.getsize')
-    def test_disconnect(
-            self, getsize, upload_vmdk, file_open, create_temp_ds_folder,
-            get_ds_by_ref):
+    def test_disconnect(self, upload_vmdk, create_temp_ds_folder,
+                        get_ds_by_ref):
         ds_ref = mock.sentinel.ds_ref
         ds_name = 'datastore-1'
         dstore = datastore.Datastore(ds_ref, ds_name)
         get_ds_by_ref.return_value = dstore
 
-        file_open_ret = mock.Mock()
         tmp_file = mock.sentinel.tmp_file
-        file_open_ret.__enter__ = mock.Mock(return_value=tmp_file)
-        file_open_ret.__exit__ = mock.Mock(return_value=None)
-        file_open.return_value = file_open_ret
 
         dc_name = mock.sentinel.dc_name
         delete_task = mock.sentinel.delete_vdisk_task
@@ -243,19 +239,18 @@ class VmdkConnectorTestCase(test_connector.ConnectorTestCase):
         session.invoke_api.side_effect = [
             dc_name, delete_task, copy_task, delete_file_task]
 
-        getsize.return_value = units.Gi
-
         tmp_file_path = '/tmp/foo.vmdk'
         dc_ref = mock.sentinel.dc_ref
         vmdk_path = mock.sentinel.vmdk_path
+        file_size = 1024
         self._connector._disconnect(
-            tmp_file_path, session, ds_ref, dc_ref, vmdk_path)
+            session, tmp_file_path, tmp_file, file_size, ds_ref, dc_ref,
+            vmdk_path)
 
         tmp_folder_path = self._connector.TMP_IMAGES_DATASTORE_FOLDER_PATH
         ds_folder_path = '[%s] %s' % (ds_name, tmp_folder_path)
         create_temp_ds_folder.assert_called_once_with(
             session, ds_folder_path, dc_ref)
-        file_open.assert_called_once_with(tmp_file_path, "rb")
 
         self.assertEqual(
             mock.call(vim_util, 'get_object_property', session.vim, dc_ref,
@@ -265,7 +260,7 @@ class VmdkConnectorTestCase(test_connector.ConnectorTestCase):
         upload_vmdk.assert_called_once_with(
             tmp_file, self._connector._ip, self._connector._port, dc_name,
             ds_name, session.vim.client.options.transport.cookiejar,
-            exp_rel_path, units.Gi, self._connector._ca_file,
+            exp_rel_path, file_size, self._connector._ca_file,
             self._connector._timeout)
 
         disk_mgr = session.vim.service_content.virtualDiskManager
@@ -292,6 +287,47 @@ class VmdkConnectorTestCase(test_connector.ConnectorTestCase):
             session.invoke_api.call_args_list[3])
         self.assertEqual(mock.call(delete_file_task),
                          session.wait_for_task.call_args_list[2])
+
+    @mock.patch('oslo_vmware.image_transfer._start_transfer')
+    @mock.patch('oslo_vmware.rw_handles.VmdkWriteHandle')
+    @mock.patch('oslo_vmware.vim_util.get_moref')
+    @mock.patch('os_brick.initiator.connectors.vmware.VolumeOps')
+    def test_disconnect_with_import(self, vops, get_moref, vmdk_write_handle,
+                                    start_transfer):
+        import_spec = mock.Mock()
+        session = mock.sentinel.session
+        backing = mock.sentinel.backing
+        tmp_file = mock.sentinel.file
+        file_size = 1024
+        import_data = {
+            'folder': mock.sentinel.folder,
+            'resource_pool': mock.sentinel.resource_pool
+        }
+        vops._session = mock.sentinel._session
+        vops.get_import_spec.return_value = import_spec
+        get_moref.side_effect = [import_data['folder'], import_data[
+            'resource_pool']]
+        vmdk_write_handle_ret = mock.sentinel.vmdk_write_handle
+        vmdk_write_handle.return_value = vmdk_write_handle_ret
+
+        self._connector._disconnect_with_import(import_data, vops,
+                                                backing, tmp_file, file_size)
+
+        vops.delete_backing.assert_called_once_with(backing)
+
+        vmdk_write_handle.assert_called_once_with(vops._session,
+                                    self._connector._ip,
+                                    self._connector._port,
+                                    import_data['resource_pool'],
+                                    import_data['folder'],
+                                    import_spec,
+                                    file_size,
+                                    'POST')
+
+        start_transfer.assert_called_once_with(tmp_file,
+                                               vmdk_write_handle_ret,
+                                               self._connector._timeout)
+
 
     @mock.patch('os.path.exists')
     def test_disconnect_volume_with_missing_temp_file(self, path_exists):
@@ -324,6 +360,9 @@ class VmdkConnectorTestCase(test_connector.ConnectorTestCase):
         disconnect.assert_not_called()
         remove.assert_called_once_with(path)
 
+    @mock.patch('os_brick.initiator.connectors.vmware.VolumeOps')
+    @mock.patch('os_brick.initiator.connectors.vmware.open', create=True)
+    @mock.patch('os.path.getsize')
     @mock.patch('os.path.exists')
     @mock.patch('os.path.getmtime')
     @mock.patch.object(VMDK_CONNECTOR, '_load_config')
@@ -332,11 +371,15 @@ class VmdkConnectorTestCase(test_connector.ConnectorTestCase):
     @mock.patch.object(VMDK_CONNECTOR, '_snapshot_exists')
     @mock.patch.object(VMDK_CONNECTOR, '_disconnect')
     @mock.patch('os.remove')
+    @mock.patch.object(VMDK_CONNECTOR, '_disconnect_with_import')
     def test_disconnect_volume(
-            self, remove, disconnect, snapshot_exists, get_moref,
-            create_session, load_config, getmtime, path_exists):
-        path_exists.return_value = True
+            self, disconnect_with_import, remove, disconnect, snapshot_exists,
+            get_moref, create_session, load_config, getmtime, path_exists,
+            path_getsize, open_file, vops, import_data=False):
 
+        path_exists.return_value = True
+        file_size = 1024
+        path_getsize.return_value = file_size
         mtime = 1467802060
         getmtime.return_value = mtime
 
@@ -351,16 +394,181 @@ class VmdkConnectorTestCase(test_connector.ConnectorTestCase):
         get_moref.side_effect = [backing, ds_ref, dc_ref]
 
         props = self._create_connection_properties()
+        if import_data:
+            props['import_data'] = {'vm': {}}
+
         path = mock.sentinel.path
+        tmp_file = mock.sentinel.tmp_file
+        file_open_ret = mock.Mock()
+        file_open_ret.__enter__ = mock.Mock(return_value=tmp_file)
+        file_open_ret.__exit__ = mock.Mock(return_value=None)
+        open_file.return_value = file_open_ret
+        vops_ret = mock.Mock(_session=session)
+        vops.return_value = vops_ret
+
         self._connector.disconnect_volume(props, {'path': path,
                                                   'last_modified': mtime - 1})
-
         path_exists.assert_called_once_with(path)
         getmtime.assert_called_once_with(path)
+        open_file.assert_called_once_with(path, "rb")
         load_config.assert_called_once_with(props)
         create_session.assert_called_once_with()
         snapshot_exists.assert_called_once_with(session, backing)
-        disconnect.assert_called_once_with(
-            path, session, ds_ref, dc_ref, props['vmdk_path'])
+        path_getsize.assert_called_once_with(path)
+        if import_data:
+            disconnect.assert_not_called()
+            disconnect_with_import.assert_called_once_with(
+                props['import_data'], vops_ret, backing, tmp_file, file_size)
+        else:
+            disconnect.assert_called_once_with(
+            session, path, tmp_file, file_size, ds_ref, dc_ref,
+                props['vmdk_path'])
+            disconnect_with_import.assert_not_called()
         remove.assert_called_once_with(path)
         session.logout.assert_called_once_with()
+
+    def test_disconnect_volume_with_import(self):
+        self.test_disconnect_volume(import_data=True)
+
+    @staticmethod
+    def _create_import_data(folder=None, rp=None):
+        return {
+            'profile_id': 'profile-1',
+            'folder': folder.value if folder else mock.Mock(),
+            'resource_pool': rp.value if rp else mock.Mock(),
+            'vm': {
+                'name': 'vm-1',
+                'uuid': '0-1-2-3',
+                'path_name': '[ds-1]',
+                'guest_id': 'guest-id',
+                'num_cpus': 1,
+                'memory_mb': 128,
+                'vmx_version': 'vmx-8',
+                'extension_key': 'foo-extension-key',
+                'extension_type': 'foo-extension-type',
+                'extra_config': {'foo': 'bar'}
+            },
+            'adapter_type': mock.Mock(),
+            'controller': {
+                'type': 'controllerTypeOne',
+                'key': 1,
+                'create': True,
+                'shared_bus': 'shared',
+                'bus_number': 1
+            },
+            'disk': {
+                'type': 'diskTypeOne',
+                'key': -101,
+                'capacity_in_kb': 1024 * 1024,
+                'eagerly_scrub': None,
+                'thin_provisioned': True
+            }
+        }
+
+    def test_volumeops_get_vm_config_spec(self):
+        session = mock.Mock()
+        cf = mock.Mock()
+        session.vim.client.factory = cf
+
+        vm_file_info = mock.Mock()
+        config_spec = mock.Mock()
+        extra_config = mock.Mock()
+        vm_profile = mock.Mock()
+        managed_by = mock.Mock()
+        controller_device = mock.Mock()
+        controller_spec = mock.Mock()
+        disk_device = mock.Mock()
+        disk_backing = mock.Mock()
+        disk_spec = mock.Mock()
+        disk_profile = mock.Mock()
+
+        cf.create.side_effect = [vm_file_info, config_spec, extra_config,
+                                 vm_profile, managed_by, controller_device,
+                                 controller_spec, disk_device, disk_backing,
+                                 disk_spec, disk_profile]
+
+        data = self._create_import_data()
+
+        vops = vmware.VolumeOps(session)
+        spec = vops.get_vm_config_spec(data)
+
+        cf.create.assert_has_calls([
+            mock.call('ns0:VirtualMachineFileInfo'),
+            mock.call('ns0:VirtualMachineConfigSpec'),
+            mock.call('ns0:OptionValue'),
+            mock.call('ns0:VirtualMachineDefinedProfileSpec'),
+            mock.call('ns0:ManagedByInfo'),
+            mock.call('ns0:%s' % data['controller']['type']),
+            mock.call('ns0:VirtualDeviceConfigSpec'),
+            mock.call('ns0:VirtualDisk'),
+            mock.call('ns0:VirtualDiskFlatVer2BackingInfo'),
+            mock.call('ns0:VirtualDeviceConfigSpec'),
+            mock.call('ns0:VirtualMachineDefinedProfileSpec'),
+        ])
+
+        vm = data['vm']
+        self.assertEqual(spec.files.vmPathName, vm['path_name'])
+        self.assertEqual(spec.guestId, vm['guest_id'])
+        self.assertEqual(spec.numCPUs, vm['num_cpus'])
+        self.assertEqual(spec.memoryMB, vm['memory_mb'])
+        self.assertEqual(spec.files, vm_file_info)
+        self.assertEqual(spec.version, vm['vmx_version'])
+        self.assertEqual(spec.instanceUuid, vm['uuid'])
+        self.assertEqual(spec.extraConfig, [extra_config])
+        self.assertEqual(spec.vmProfile, vm_profile)
+        self.assertEqual(spec.vmProfile.profileId, data['profile_id'])
+        self.assertEqual(spec.managedBy, managed_by)
+        self.assertEqual(extra_config.key, 'foo')
+        self.assertEqual(extra_config.value, 'bar')
+        self.assertEqual(spec.deviceChange, [disk_spec, controller_spec])
+
+        disk = data['disk']
+        ctrl = data['controller']
+
+        self.assertEqual(controller_spec.device, controller_device)
+        self.assertEqual(controller_device.key, ctrl['key'])
+        self.assertEqual(controller_device.busNumber, ctrl['bus_number'])
+        self.assertEqual(controller_device.sharedBus, ctrl['shared_bus'])
+
+        self.assertEqual(disk_device.capacityInKB, disk['capacity_in_kb'])
+        self.assertEqual(disk_device.key, disk['key'])
+        self.assertEqual(disk_device.unitNumber, 0)
+        self.assertEqual(disk_device.controllerKey, ctrl['key'])
+
+        self.assertEqual(disk_device.backing, disk_backing)
+        self.assertEqual(disk_backing.thinProvisioned, True)
+        self.assertEqual(disk_backing.fileName, '')
+        self.assertEqual(disk_backing.diskMode, 'persistent')
+
+        self.assertEqual(disk_spec.operation, 'add')
+        self.assertEqual(disk_spec.fileOperation, 'create')
+        self.assertEqual(disk_spec.device, disk_device)
+        self.assertEqual(disk_spec.profile, [disk_profile])
+        self.assertEqual(disk_profile.profileId, data['profile_id'])
+
+    @mock.patch.object(VMDK_VOLUMEOPS, 'get_vm_config_spec')
+    def test_volumeops_get_import_spec(self, get_vm_config_spec):
+        session = mock.Mock()
+        cf = mock.Mock()
+        session.vim.client.factory = cf
+        config_spec = mock.Mock()
+        get_vm_config_spec.return_value = config_spec
+
+        vops = vmware.VolumeOps(session)
+        spec = vops.get_import_spec(self._create_import_data())
+
+        cf.create.assert_called_once_with('ns0:VirtualMachineImportSpec')
+        self.assertEquals(spec.configSpec, config_spec)
+
+    def test_volumeops_delete_backing(self):
+        session = mock.Mock(vim=mock.Mock())
+        backing = mock.Mock()
+        task = mock.Mock()
+        session.invoke_api.return_value = task
+
+        vops = vmware.VolumeOps(session)
+        vops.delete_backing(backing)
+
+        session.invoke_api.assert_called_once_with(session.vim,
+                                                   'Destroy_Task', backing)
+        session.wait_for_task.assert_called_once_with(task)


### PR DESCRIPTION
This refactors most of the vmware connector.
We switch to returning VmdkWriteHandle and VmdkReadHandle instead of local filesystem paths,
so that we can backup and restore volumes directly from/into VMware.